### PR TITLE
remove testrunner for correct diagnostics

### DIFF
--- a/runTests.m
+++ b/runTests.m
@@ -6,11 +6,16 @@ function results = runTests(testsPath)
     
     import matlab.unittest.TestSuite;
     import matlab.unittest.TestRunner;
+    import matlab.unittest.plugins.*;
     
     suite = TestSuite.fromFolder(testsPath, ...
                                  'IncludingSubfolders', true);
     
+    % Create TestRunner
+    runner = TestRunner.withTextOutput; % Contains TestRunProgressPlugin, DiagnosticsOutputPlugin
+    runner.addPlugin(DiagnosticsRecordingPlugin);
+    
     % Run the tests
-    results = run(suite);
+    results = runner.run(suite);
     
 end

--- a/runTests.m
+++ b/runTests.m
@@ -10,10 +10,7 @@ function results = runTests(testsPath)
     suite = TestSuite.fromFolder(testsPath, ...
                                  'IncludingSubfolders', true);
     
-    % Build the runner
-    runner = TestRunner.withTextOutput;
-    
     % Run the tests
-    results = runner.run(suite);
+    results = run(suite);
     
 end


### PR DESCRIPTION
Remove the testRunner object for correct diagnostics. 

Both in the applications PR and WEC-Sim repo PR, the testrunner does not contain correct diagnostic information when a test fails. I have found that using the ``run(suites)`` command provides better information and gives the same textual output information as the ``TestRunner.withTextOutput``.